### PR TITLE
Allow Account Type to be set ("E", "M" or "C" for Ecommerce, MO/TO, C…

### DIFF
--- a/src/Shared.php
+++ b/src/Shared.php
@@ -109,6 +109,30 @@ class Shared extends AbstractSettings
     }
 
     /**
+     * Get value of Account Type
+     *
+     * @return string  Account Type option
+     */
+    public function getAccountType()
+    {
+        return $this->accountType;
+    }
+
+    /**
+     * Set value of Account Type
+     *
+     * @param int $applyAvsCv2 Apply AVS/CV2 validation option
+     */
+    public function setAccountType($accountType)
+    {
+        if (in_array($accountType, ["E", "M", "C"])) {
+            $this->accountType = $accountType;
+        } else {
+            throw new InvalidArgumentException("Invalid AccountType value, [\"E\", \"M\", \"C\"] expected, " . $accountType . " given");
+        }
+    }
+
+    /**
      * Get value of 3D Secure Verification option
      *
      * @return int  3D Secure Verification option

--- a/tests/SharedTest.php
+++ b/tests/SharedTest.php
@@ -100,6 +100,31 @@ class SharedTest extends PHPUnit_Framework_TestCase
         
     }
 
+    public function testSetAccountTypeException()
+    {
+        $shared = new dwmsw\sagepay\Shared();
+
+        try {
+           $shared->setAccountType("XXXX");
+        } catch (InvalidArgumentException $expected) {
+            return;
+        }
+
+        $this->fail('An expected exception has not been raised.');
+    }
+
+    public function testSetAccountType()
+    {
+        $shared = new dwmsw\sagepay\Shared();
+
+        $return = $shared->setAccountType("C");
+
+        $accountType = $shared->getAccountType();
+
+        $this->assertEquals($accountType, "C");
+
+    }
+
     public function testSetApply3dSecureException()
     {
         $shared = new dwmsw\sagepay\Shared();


### PR DESCRIPTION
Allow Account Type to be set
E - Ecommerce
M - Moto
C - Continous Authority